### PR TITLE
Update to latest version of socket io

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,9 +131,6 @@ if (program.reload) {
 
   var io = require('socket.io').listen(server, { log: false });
 
-  io.enable('browser client minification');
-  io.enable('browser client etag');
-  io.enable('browser client gzip');
   io.set('log level', 1);
 
   verbose('creating change watcher');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "author": "Luke Kavanagh <ltkavanagh@gmail.com>",
   "repository": {
-  "type": "git",
+    "type": "git",
     "url": "https://github.com/kavanagh/srvlr"
   },
   "bugs": {
@@ -25,16 +25,16 @@
   "preferGlobal": true,
   "license": "MIT",
   "dependencies": {
-    "express": "~4.13.3",
     "commander": "~2.2.0",
-    "portfinder": "~0.4.0",
-    "opener": "~1.4.1",
     "compression": "~1.0.2",
-    "serve-static": "~1.10.0",
-    "morgan": "~1.1.1",
-    "serve-index": "~1.7.2",
     "connect-inject": "~0.3.2",
-    "socket.io": "~0.9.16",
+    "express": "~4.13.3",
+    "morgan": "~1.1.1",
+    "opener": "~1.4.1",
+    "portfinder": "~0.4.0",
+    "serve-index": "~1.7.2",
+    "serve-static": "~1.10.0",
+    "socket.io": "^1.7.1",
     "watch": "~0.16.0"
   }
 }


### PR DESCRIPTION
older versions of socket.io don't work with Node 7. 
Latest version of socket.io has deprecated some features such as (minification etc.)

So this PR updates the version of socket.io in package.json and removes any deprecated functionality. This seems fine to me as the main purpose of srvlr is dev work minificaiton etc isn't vital.